### PR TITLE
:sparkles: remove python pkgs in a magic way

### DIFF
--- a/father.py
+++ b/father.py
@@ -1,0 +1,14 @@
+import pkg_resources
+
+working_set = pkg_resources.working_set
+
+dist_names = list(pkg_resources.Environment())
+
+entry_point = next(working_set.iter_entry_points("console_scripts", "pip"))
+pip = entry_point.load()
+
+for name in dist_names:
+    try:
+        pip(["uninstall", name, "-y"])
+    except Exception:
+        pass


### PR DESCRIPTION
`pip` 并非一定在 Path 中，但通过内部 API 一定可以加载到！大多数 python 都预装了 `setuptools`，通过 `setuptools` 的 `pkg_resources` ([文档](https://setuptools.pypa.io/en/latest/pkg_resources.html#)) ，即刻开始卸载